### PR TITLE
Added 'messaging-activemq' subsystem configuration

### DIFF
--- a/web/src/main/docker/assembly/assembly.xml
+++ b/web/src/main/docker/assembly/assembly.xml
@@ -40,10 +40,5 @@
             <outputDirectory>${jboss.home}/extensions</outputDirectory>
             <fileMode>0777</fileMode>
         </fileSet>
-        <fileSet>
-            <directory>${project.build.directory}/classes/configuration</directory>
-            <outputDirectory>${jboss.home}/standalone/configuration</outputDirectory>
-            <fileMode>0777</fileMode>
-        </fileSet>
     </fileSets>
 </assembly>

--- a/web/src/main/resources/cli/setup.cli
+++ b/web/src/main/resources/cli/setup.cli
@@ -1,5 +1,8 @@
 embed-server --std-out=echo --admin-only=true --server-config=standalone-openshift.xml
 
+/subsystem=ejb3:write-attribute(name="default-mdb-instance-pool", value="mdb-strict-max-pool")
+/subsystem=ejb3:write-attribute(name="default-resource-adapter-name", value="${ejb.resource-adapter-name:activemq-ra.rar}")
+
 /subsystem=ejb3/mdb-delivery-group=dg_executors:add()
 /subsystem=ejb3/mdb-delivery-group=dg_services:add()
 

--- a/web/src/main/resources/extensions/jms.cli
+++ b/web/src/main/resources/extensions/jms.cli
@@ -1,8 +1,28 @@
 embed-server --std-out=echo  --server-config=standalone-openshift.xml
 
-jms-queue add --queue-address=executorQueue --entries=[queues/executorQueue,java:jboss/exported/jms/queues/executorQueue]
-jms-queue add --queue-address=statusUpdateQueue --entries=[queues/statusUpdateQueue,java:jboss/exported/jms/queues/statusUpdateQueue]
-jms-queue add --queue-address=packageDiscoveryQueue --entries=[queues/packageDiscoveryQueue]
-jms-topic add --topic-address=executorCancellation --entries=[topics/executorCancellation,java:jboss/exported/jms/topics/executorCancellation]
+/subsystem=ee/service=default-bindings:write-attribute(name=jms-connection-factory, value=java:jboss/DefaultJMSConnectionFactory)
+
+/extension=org.wildfly.extension.messaging-activemq:add
+
+/subsystem="messaging-activemq":add()
+/subsystem="messaging-activemq"/server="default":add(statistics-enabled="${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}")
+/subsystem="messaging-activemq"/server="default"/http-acceptor="http-acceptor":add(http-listener="default")
+/subsystem="messaging-activemq"/server="default"/http-acceptor="http-acceptor-throughput":add(http-listener="default",params={"batch-delay" => "50","direct-deliver" => "false"})
+/subsystem="messaging-activemq"/server="default"/http-connector="http-connector":add(endpoint="http-acceptor",socket-binding="http")
+/subsystem="messaging-activemq"/server="default"/http-connector="http-connector-throughput":add(endpoint="http-acceptor-throughput",params={"batch-delay" => "50"},socket-binding="http")
+/subsystem="messaging-activemq"/server="default"/in-vm-acceptor="in-vm":add(params={"buffer-pooling" => "false"},server-id="0")
+/subsystem="messaging-activemq"/server="default"/in-vm-connector="in-vm":add(params={"buffer-pooling" => "false"},server-id="0")
+/subsystem="messaging-activemq"/server="default"/jms-queue="ExpiryQueue":add(entries=["java:/jms/queue/ExpiryQueue"])
+/subsystem="messaging-activemq"/server="default"/jms-queue="DLQ":add(entries=["java:/jms/queue/DLQ"])
+/subsystem="messaging-activemq"/server="default"/jms-queue="executorQueue":add(entries=["queues/executorQueue"])
+/subsystem="messaging-activemq"/server="default"/jms-queue="statusUpdateQueue":add(entries=["queues/statusUpdateQueue"])
+/subsystem="messaging-activemq"/server="default"/jms-queue="packageDiscoveryQueue":add(entries=["queues/packageDiscoveryQueue"])
+/subsystem="messaging-activemq"/server="default"/jms-topic="executorCancellation":add(entries=["topics/executorCancellation"])
+/subsystem="messaging-activemq"/server="default"/pooled-connection-factory="activemq-ra":add(connectors=["in-vm"],entries=["java:/JmsXA","java:jboss/DefaultJMSConnectionFactory"],transaction="xa")
+/subsystem="messaging-activemq"/server="default"/security-setting="#":add()
+/subsystem="messaging-activemq"/server="default"/security-setting="#"/role="guest":add(consume="true",create-non-durable-queue="true",delete-non-durable-queue="true",send="true")
+/subsystem="messaging-activemq"/server="default"/connection-factory="InVmConnectionFactory":add(connectors=["in-vm"],entries=["java:/ConnectionFactory"])
+/subsystem="messaging-activemq"/server="default"/connection-factory="RemoteConnectionFactory":add(connectors=["http-connector"],entries=["java:jboss/exported/jms/RemoteConnectionFactory"])
+/subsystem="messaging-activemq"/server="default"/address-setting="#":add(dead-letter-address="jms.queue.DLQ",expiry-address="jms.queue.ExpiryQueue",max-size-bytes="10485760",message-counter-history-day-limit="10",page-size-bytes="2097152")
 
 quit

--- a/web/src/main/resources/extensions/postconfigure.sh
+++ b/web/src/main/resources/extensions/postconfigure.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -x
 echo "Creating Windup Queues and Topics"
-$JBOSS_HOME/bin/jboss-cli.sh --file=$JBOSS_HOME/extensions/jms.cli
+$JBOSS_HOME/bin/jboss-cli.sh --echo-command --file=$JBOSS_HOME/extensions/jms.cli


### PR DESCRIPTION
- added `messaging-activemq` subsystem configuration
- added `--echo-command` when executing `jms.cli` in order to know easily which was the failures during development
- avoided `standalone.xml` copy removing a `fileset` in `assembly.xml` (`standalone.xml` not removed yet)
